### PR TITLE
Add email queue logging capability

### DIFF
--- a/src/Helper/Data.php
+++ b/src/Helper/Data.php
@@ -2,5 +2,10 @@
 
 class Zenc_EmailLogger_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    const XML_PATH_ENABLED = 'dev/email_logger/enabled';
 
+    public function isEnabled()
+    {
+        return Mage::getStoreConfigFlag(self::XML_PATH_ENABLED);
+    }
 }

--- a/src/Model/Core/Email/Template.php
+++ b/src/Model/Core/Email/Template.php
@@ -11,7 +11,7 @@ class Zenc_EmailLogger_Model_Core_Email_Template extends Mage_Core_Model_Email_T
      */
     public function getMail()
     {
-        if (!Mage::getStoreConfigFlag(self::XML_PATH_ENABLED)) {
+        if (!Mage::helper('zenc_emaillogger')->isEnabled()) {
             return parent::getMail();
         }
 

--- a/src/Model/Email/Queue.php
+++ b/src/Model/Email/Queue.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Extend email queue functionality with logging capability
+ */
+class Zenc_EmailLogger_Model_Email_Queue extends Mage_Core_Model_Email_Queue
+{
+    /**
+     * Send all messages in a queue
+     *
+     * Log messages instead of sending if email logging is enabled
+     *
+     * @return Mage_Core_Model_Email_Queue
+     */
+    public function send()
+    {
+        if (!Mage::helper('zenc_emaillogger')->isEnabled()) {
+            return parent::send();
+        }
+
+        $this->_logQueue();
+
+        return $this;
+    }
+
+    /**
+     * Log queued emails and mark them as processed
+     *
+     * @throws Exception Thrown when unable to save message
+     */
+    private function _logQueue()
+    {
+        /** @var $collection Mage_Core_Model_Resource_Email_Queue_Collection */
+        $collection = Mage::getModel('core/email_queue')->getCollection()
+            ->addOnlyForSendingFilter()
+            ->setPageSize(self::MESSAGES_LIMIT_PER_CRON_RUN)
+            ->setCurPage(1)
+            ->load();
+
+        $logger = Mage::getModel('zenc_emaillogger/email_queue_logger');
+        foreach ($collection as $message) {
+            $logger->save($message);
+
+            $message->setProcessedAt(Varien_Date::formatDate(true));
+            $message->save();
+        }
+    }
+}

--- a/src/Model/Email/Queue/Logger.php
+++ b/src/Model/Email/Queue/Logger.php
@@ -1,0 +1,42 @@
+<?php
+
+class Zenc_EmailLogger_Model_Email_Queue_Logger
+{
+    /**
+     * Save email queue to log
+     *
+     * @param Mage_Core_Model_Email_Queue $queue
+     *
+     * @throws Exception Thrown when unable to save the log
+     */
+    public function save(Mage_Core_Model_Email_Queue $queue)
+    {
+        $log = $this->_covertEmailQueueToLog($queue);
+        $log->save();
+    }
+
+    /**
+     * @param Mage_Core_Model_Email_Queue $queue
+     *
+     * @return Zenc_EmailLogger_Model_Log
+     */
+    private function _covertEmailQueueToLog(Mage_Core_Model_Email_Queue $queue)
+    {
+        $log = Mage::getModel('zenc_emaillogger/log');
+        $parameters = $queue->getMessageParameters();
+
+        if ($parameters['is_plain']) {
+            $log->setBodyText($queue->getMessageBody());
+        } else {
+            $log->setBodyHtml($queue->getMessageBody());
+        }
+        $log->setRecipients($queue->getRecipients());
+        $log->setSubject($parameters['subject']);
+        $log->setFromEmail($parameters['from_email']);
+        $log->setFromName($parameters['from_name']);
+        $log->setReplyToEmail($parameters['reply_to']);
+        $log->setReturnPath($parameters['return_to']);
+
+        return $log;
+    }
+}

--- a/src/Model/Zend/Mail/Logger.php
+++ b/src/Model/Zend/Mail/Logger.php
@@ -58,24 +58,6 @@ class Zenc_EmailLogger_Model_Zend_Mail_Logger extends Zend_Mail
     }
 
     /**
-     * Adds To-header and recipient, $email can be an array, or a single string address
-     *
-     * @param string|array $email
-     * @param string $name
-     *
-     * @return Zenc_EmailLogger_Zend_Mail_Logger Provides fluent interface
-     */
-    public function addTo($email, $name = '')
-    {
-        if (!$this->getLog()->hasToEmail()) {
-            $this->getLog()->setToEmail($email);
-            $this->getLog()->setToName($this->_decodeBase64Header($name));
-        }
-
-        return parent::addTo($email, $name);
-    }
-
-    /**
      * Helper function for adding a recipient and the corresponding header
      *
      * @param string $headerName
@@ -84,11 +66,16 @@ class Zenc_EmailLogger_Model_Zend_Mail_Logger extends Zend_Mail
      */
     protected function _addRecipientAndHeader($headerName, $email, $name)
     {
-        $this->getLog()->addRecipient(
-            $headerName,
-            $email,
-            $this->_decodeBase64Header($name)
-        );
+        if (!$this->getLog()->hasToEmail() && $headerName === 'To') {
+            $this->getLog()->setToEmail($email);
+            $this->getLog()->setToName($this->_decodeBase64Header($name));
+        } else {
+            $this->getLog()->addRecipient(
+                $headerName,
+                $email,
+                $this->_decodeBase64Header($name)
+            );
+        }
 
         parent::_addRecipientAndHeader($headerName, $email, $name);
     }

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -22,6 +22,7 @@
             <core>
                 <rewrite>
                     <email_template>Zenc_EmailLogger_Model_Core_Email_Template</email_template>
+                    <email_queue>Zenc_EmailLogger_Model_Email_Queue</email_queue>
                 </rewrite>
             </core>
         </models>


### PR DESCRIPTION
In particular cases Magento sends emails asynchronously via email queues.
This commit extends the current logging functionality to cover queued emails as well.
