### PR TITLE
Set default charset to UTF-8

### DIFF
--- a/src/Model/Zend/Mail/Logger.php
+++ b/src/Model/Zend/Mail/Logger.php
@@ -14,7 +14,7 @@ class Zenc_EmailLogger_Model_Zend_Mail_Logger extends Zend_Mail
      */
     public function __construct($charset = null)
     {
-        if ($charset === null) {
+        if (empty($charset)) {
             $charset = 'utf-8';
         }
 


### PR DESCRIPTION
Mage::getModel() passes an empty array to the constructor which makes the Zend_Mail class to send out the body in ISO-8859-1 encoding.
This commit fixes that.
